### PR TITLE
adjusted errors and hints

### DIFF
--- a/content/modules/ROOT/pages/03-03-hints.adoc
+++ b/content/modules/ROOT/pages/03-03-hints.adoc
@@ -22,7 +22,7 @@ GH link: https://github.com/rh-aiservices-bu/ai-mazing-race
 * small - pytorch - wb, with 5 GB of disk.
 * Navigate to lab-materials/03 and open stars-classification.ipynb
 
-* train_test_split has something wrong...
+* train_test_split has something wrong... maybe changing some range in the parameters?
 * plt.show() is used to visualize the confusion matrix
 
 * In the Jupyter Notebook, you have the possibility to use Elyra pipelines...
@@ -36,7 +36,7 @@ GH link: https://github.com/rh-aiservices-bu/ai-mazing-race
 ====
 
 * !pip install seaborn
-* remove rhoai_is_great=True from train_test_split in "Train the Model" section
+* adjust the test_size to 0.3 from train_test_split in "Train the Model" section as the 30% of the data is used for testing
 * substitute plt.show_me_the_stars with plt.show()
 * From the Jupyter Notebook add a New Data Science Pipeline Editor, and drag and drop the stars-classification.ipynb file
 * Run the pipeline from Elyra / Data Science Pipeline Editor

--- a/lab-materials/03/stars-classification.ipynb
+++ b/lab-materials/03/stars-classification.ipynb
@@ -398,8 +398,8 @@
    "outputs": [],
    "source": [
     "# Split the data into training and testing sets\n",
-    "# 30% of the data is used for testing, while the remaining 70% is used for training\n",
-    "X_train, X_test, y_train, y_test = train_test_split(features, target, test_size=0.3, random_state=42, rhoai_is_great=True)"
+    "# 30% of the data is used for testing, while the remaining 70% is used for training.\n",
+    "X_train, X_test, y_train, y_test = train_test_split(features, target, test_size=1.5, random_state=42)"
    ]
   },
   {


### PR DESCRIPTION
Instead of using rhoai_is_great=True in the train_test_split function, I have opted to demonstrate the use of existing parameters. No deprecated parameters were found that would fail, as scikit-learn maintains backward compatibility.

The issue I introduced involves setting train_size to 1.5 (150%) instead of 0.3 (30%). The resulting error is self-explanatory, allowing users to understand and correct the problem by reading the error log (though interpreting error messages can sometimes be challenging). Additionally, the comment line explicitly describes the intended behavior to guide users.

Hints have been updated accordingly.